### PR TITLE
Fix improper string + int concatenation

### DIFF
--- a/src/CallableParameterMetaData.cpp
+++ b/src/CallableParameterMetaData.cpp
@@ -17,7 +17,6 @@
    51 Franklin St., Fifth Floor, Boston, MA 02110, USA
 *************************************************************************************/
 
-
 #include "CallableParameterMetaData.h"
 
 #include "ColumnType.h"
@@ -59,7 +58,7 @@ namespace mariadb
   void CallableParameterMetaData::setIndex(uint32_t index)
   {
     if (index < 1 || index > parameterCount) {
-      throw SQLException("invalid parameter index " + index);
+      throw SQLException(std::string("invalid parameter index ") + std::to_string(index));
     }
     rs->absolute(index);
   }

--- a/src/CallableParameterMetaData.cpp
+++ b/src/CallableParameterMetaData.cpp
@@ -17,6 +17,7 @@
    51 Franklin St., Fifth Floor, Boston, MA 02110, USA
 *************************************************************************************/
 
+
 #include "CallableParameterMetaData.h"
 
 #include "ColumnType.h"


### PR DESCRIPTION
When using the `+` operator on a string literal (which is natively a `char*`) and an integer, you are actually adding to the pointer value rather than concatenating to the string. Instead, by first explicitly constructing an `std::string` from the string literal, and second using `std::to_string` on the integer, the string will be properly concatenated.