### PR TITLE
Unit test for Pull Request #9

### DIFF
--- a/test/unit/bugs/bugs.cpp
+++ b/test/unit/bugs/bugs.cpp
@@ -1572,6 +1572,38 @@ void bugs::concpp60()
   }
 }
 
+void bugs::change_request_9()
+{
+  char buffer[] = "(values was 0x 0)";
+  logMsg("bugs::change_request_9");
+
+  // Initialize prepared statement
+  pstmt.reset(con->prepareStatement("SELECT NULL"));
+
+  // Check for all target locations of the segmentation fault
+  for(int8_t i = 0; i < 16; ++i)
+  {
+    try
+    {
+      pstmt->setByte(3, i << 4);
+    }
+    catch(sql::SQLException const &e)
+    {
+      buffer[14] = i < 10 ? (char)i + 48 : (char)i + 65 - 10;
+
+      if(!strstr(e.what(), buffer))
+      {
+        fprintf(stderr, "The error message:\n%s\n\n", e.what());
+        fprintf(stderr, "Does not contain: %s\n\n", buffer);
+
+        fail("Incorrect calculation of hex value", __FILE__, __LINE__);
+      }
+    }
+  }
+
+  pstmt->execute();
+}
+
 } /* namespace regression */
 } /* namespace testsuite */
 

--- a/test/unit/bugs/bugs.h
+++ b/test/unit/bugs/bugs.h
@@ -80,6 +80,7 @@ public:
     TEST_CASE(concpp48);
     TEST_CASE(concpp62);
     TEST_CASE(concpp60);
+    TEST_CASE(change_request_9);
   }
 
   /**
@@ -147,6 +148,8 @@ public:
   void concpp48();
   void concpp62();
   void concpp60();
+
+  void change_request_9();
 };
 
 REGISTER_FIXTURE(bugs);


### PR DESCRIPTION
This is the unit test that was requested in the conversation of pull request #9 by [jrmelsha](https://github.com/jrmelsha).
I wasn't sure how you would like to have the unit test written but I think it should show you how the bug can be triggered and a related attack could be built. Adapt it as you like.
The unit test tests only parts of the problems solved in PR #9. A list of problems solved in the PR #9 that I found are:

- The only line in SQLString ByteParameter::toString() produces a memory corruption because the result of `value & 0xF0` may be outside the range of 0-15 and the operator `hexArray[] ` does not do boundary checks.
- ByteParameter::value is an `int8_t` and the right shift for values larger 127 seems to produce curious values at least when compiled with g++. This bug also appears in the 2 methods with the name "writeTo".
- The function argument of ByteParameter::ByteParameter is a `char` while it is given an `int8_t` from the calling function and the value is also stored as an `int8_t` in ByteParameter::value. As chars are neither signed nor unsigned, this may cause compiler warnings or errors depending on the compiler. (This bug does not violate the conditions of the unit test in this pull request.)