### PR TITLE
missing cstring include build error clang 13

### DIFF
--- a/test/framework/test_asserts.h
+++ b/test/framework/test_asserts.h
@@ -37,6 +37,7 @@
 #include "conncpp/ResultSet.hpp"
 
 #include "../common/ccppTypes.h"
+#include <cstring>
 
 #ifndef __LINE__
 #define __LINE__ "(line number n/a)"

--- a/test/unit/classes/resultset.cpp
+++ b/test/unit/classes/resultset.cpp
@@ -33,6 +33,7 @@
 
 #include "Warning.hpp"
 
+#include <cstring>
 #include <sstream>
 #include <cstdlib>
 #include <stdlib.h>


### PR DESCRIPTION
clang 13 on Linux is complaining about this missing import

```
] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1379:12: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]     ASSERT(std::memcmp(col3.c_str(), "a\0\0b", 4) == 0);
[cmake]            ^~~~~~~~~~~
[cmake]            memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
[cmake]            ^
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1390:12: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]     ASSERT(std::memcmp(col3.c_str(), "a\0\0b", 4) == 0);
[cmake]            ^~~~~~~~~~~
[cmake]            memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
[cmake]            ^
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1396:12: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]     ASSERT(std::memcmp(col3.c_str(), "\0a\0b", 4) == 0);
[cmake]            ^~~~~~~~~~~
[cmake]            memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
[cmake]            ^
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1402:12: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]     ASSERT(std::memcmp(col3.c_str(), "xz\0\0", 4) == 0);
[cmake]            ^~~~~~~~~~~
[cmake]            memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
[cmake]            ^
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1411:12: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]     ASSERT(std::memcmp(col3.c_str(), "xz\0\0", 4) == 0);
[cmake]            ^~~~~~~~~~~
[cmake]            memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
[cmake]            ^
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1419:12: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]     ASSERT(std::memcmp(col3.c_str(), "xz\0\0", 4) == 0);
[cmake]            ^~~~~~~~~~~
[cmake]            memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
[cmake]            ^
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1426:12: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]     ASSERT(std::memcmp(col3.c_str(), "\0a\0b", 4) == 0);
[cmake]            ^~~~~~~~~~~
[cmake]            memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
[cmake]            ^
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1432:12: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]     ASSERT(std::memcmp(col3.c_str(), "a\0\0b", 4) == 0);
[cmake]            ^~~~~~~~~~~
[cmake]            memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
[cmake]            ^
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1445:14: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]       ASSERT(std::memcmp(col3.c_str(), binVal[i].c_str(), col3.length()) == 0);
[cmake]              ^~~~~~~~~~~
[cmake]              memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
[cmake]            ^
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/resultset.cpp:1461:14: error: no member named 'memcmp' in namespace 'std'; did you mean simply 'memcmp'?
[cmake]       ASSERT(std::memcmp(col3.c_str(), binVal[i].c_str(), col3.length()) == 0);
[cmake]              ^~~~~~~~~~~
[cmake]              memcmp
[cmake] /home/samuaz/Projects/pas/pas-backoffice-cpp/third_party/winter/wintercpp_mariadb/third_party/mariadb_connector/test/unit/classes/../../framework/test_asserts.h:160:44: note: expanded from macro 'ASSERT'
[cmake] #define ASSERT( exp ) assertTrue( (#exp), (exp), __FILE__, __LINE__)
[cmake]                                            ^~~
[cmake] /usr/include/string.h:64:12: note: 'memcmp' declared here
[cmake] extern int memcmp (const void *__s1, const void *__s2, size_t __n)
```