### PR TITLE
Added toString() function for better performance 

### DIFF
--- a/include/conncpp/SQLString.hpp
+++ b/include/conncpp/SQLString.hpp
@@ -81,6 +81,7 @@ public:
   std::string::const_iterator cbegin() const { return begin(); }
   std::string::const_iterator cend() const { return end(); }
   void clear();
+  std::string toString();
 
   /* Few extensions to mimic some java's String functionality. Probably should be moved to standalone functions */
   int64_t hashCode() const;

--- a/src/SQLString.cpp
+++ b/src/SQLString.cpp
@@ -333,4 +333,8 @@ namespace sql
     SQLString lcThis((*theString)->c_str(), (*theString)->length()), lsThat(other.c_str(), other.length());
     return lcThis.toLowerCase().compare(lsThat.toLowerCase());
   }
+  std::string SQLString::toString()
+  {
+    return theString->get();
+  }
 }


### PR DESCRIPTION
For better performance avoiding to first copy to c_str and back to std::string.
since the underlying is a std::string.