### PR TITLE
CONCPP-134: Remove use of volatile in ServerPrepareResult::shareCounter and others

### DIFF
--- a/src/MariaDbConnection.h
+++ b/src/MariaDbConnection.h
@@ -21,6 +21,7 @@
 #ifndef _MARIADBCONNECTION_H_
 #define _MARIADBCONNECTION_H_
 
+#include <atomic>
 #include <mutex>
 
 #include "MariaDbStatement.h"
@@ -74,7 +75,7 @@ public:
   bool nullCatalogMeansCurrent;
 private:
   std::unique_ptr<CallableStatementCache> callableStatementCache;
-  volatile int32_t lowercaseTableNames= -1;
+  std::atomic<int32_t> lowercaseTableNames{-1};
   bool _canUseServerTimeout;
   bool sessionStateAware;
   int32_t stateFlag= 0 ;

--- a/src/MariaDbStatement.h
+++ b/src/MariaDbStatement.h
@@ -21,6 +21,7 @@
 #ifndef _MARIADBSTATEMENT_H_
 #define _MARIADBSTATEMENT_H_
 
+#include <atomic>
 #include <map>
 #include <mutex>
 
@@ -57,12 +58,12 @@ protected:
   bool canUseServerTimeout;
   Shared::ExceptionFactory exceptionFactory;
 
-  volatile bool closed= false;
+  std::atomic<bool> closed{false};
   int32_t queryTimeout= 0;
   int64_t maxRows= 0;
   Shared::Results results;
   int32_t fetchSize;
-  volatile bool executing= false;
+  std::atomic<bool> executing{false};
   sql::Ints batchRes;
   sql::Longs largeBatchRes;
 

--- a/src/protocol/capi/ConnectProtocol.h
+++ b/src/protocol/capi/ConnectProtocol.h
@@ -79,7 +79,7 @@ namespace capi
 
     bool readOnly= false;
     FailoverProxy* proxy= nullptr;
-    volatile bool connected= false;
+    std::atomic<bool> connected{false};
     bool explicitClosed= false;
     SQLString database;
     int64_t serverThreadId= 0;

--- a/src/util/ServerPrepareResult.h
+++ b/src/util/ServerPrepareResult.h
@@ -51,8 +51,8 @@ class ServerPrepareResult  : public PrepareResult {
   std::unique_ptr<capi::MYSQL_RES, decltype(&capi::mysql_free_result)> metadata;
   std::vector<capi::MYSQL_BIND> paramBind;
   Protocol* unProxiedProtocol;
-  volatile int32_t shareCounter= 1;
-  volatile bool isBeingDeallocate= false;
+  std::atomic<int32_t> shareCounter{1};
+  std::atomic<bool> isBeingDeallocate{false};
   std::mutex lock;
 
 public:


### PR DESCRIPTION
https://jira.mariadb.org/projects/CONCPP/issues/CONCPP-134?filter=allopenissues

When building `mariadb-connector-cpp` as a dependency, I get the following warnings:
```
[ 30%] Building CXX object CMakeFiles/mariadbclientcpp.dir/_deps/mariadb-connector-cpp-src/src/util/ServerPrepareStatementCache.cpp.o
/home/runner/work/server/server/build/_deps/mariadb-connector-cpp-src/src/util/ServerPrepareResult.cpp: In member function ‘bool sql::mariadb::ServerPrepareResult::incrementShareCounter()’:
/home/runner/work/server/server/build/_deps/mariadb-connector-cpp-src/src/util/ServerPrepareResult.cpp:157:5: warning: ‘++’ expression of ‘volatile’-qualified type is deprecated [-Wvolatile]
  157 |     shareCounter++;
      |     ^~~~~~~~~~~~
/home/runner/work/server/server/build/_deps/mariadb-connector-cpp-src/src/util/ServerPrepareResult.cpp: In member function ‘void sql::mariadb::ServerPrepareResult::decrementShareCounter()’:
/home/runner/work/server/server/build/_deps/mariadb-connector-cpp-src/src/util/ServerPrepareResult.cpp:164:5: warning: ‘--’ expression of ‘volatile’-qualified type is deprecated [-Wvolatile]
  164 |     shareCounter--;
      |     ^~~~~~~~~~~~
[ 30%] Building CXX object CMakeFiles/mariadbclientcpp.dir/_deps/mariadb-connector-cpp-src/src/com/CmdInformationSingle.cpp.o
```

This PR replaces use of `volatile TYPE` with `std::atomic<TYPE>`

**License things (I saw some mention of this in other PRs):**
The files I've modified are listed under LGPL v2.1, but I'm happy to hand over all rights to the maintainers and MariaDB group, to use in whatever way they like, under whatever license they want.