### PR TITLE
Replace sprintf usage with snprintf

### DIFF
--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -288,7 +288,7 @@ static void test_connection_0(std::unique_ptr<sql::Connection> & conn)
 
     ensure("connection is closed", !conn->isClosed());
 
-    sprintf(buff, "KILL %d", rset1->getInt(1));
+    snprintf(buff, sizeof(buff), "KILL %d", rset1->getInt(1));
 
     try {
       stmt1->execute(buff);


### PR DESCRIPTION
Extracts one of the smaller items from this previous PR: https://github.com/mariadb-corporation/mariadb-connector-cpp/pull/16

License things (I saw some mention of this in other PRs):
The files I've modified are listed under LGPL v2.1, but I'm happy to hand over all rights to the maintainers and MariaDB group, to use in whatever way they like, under whatever license they want.