### PR TITLE
Include <cstdint> in CArray.hpp

### DIFF
--- a/include/conncpp/CArray.hpp
+++ b/include/conncpp/CArray.hpp
@@ -23,6 +23,7 @@
 
 #include "buildconf.hpp"
 #include <initializer_list>
+#include <cstdint>
 #include <vector>
 
 


### PR DESCRIPTION
This fixes compilation errors on systems, where the standard library doesn't happen to include sized integer definitions in one of the already included headers.

This was an issue for me in the Docker image for Alpine 3.21, with both GCC and clang.