### PR TITLE
Add support for initCommand/MYSQL_INIT_COMMAND

### DIFF
--- a/src/options/DefaultOptions.cpp
+++ b/src/options/DefaultOptions.cpp
@@ -704,7 +704,14 @@ namespace sql
         "Default authentication client-side plugin to use",
         false,
         ""}
-      }
+      },
+      {
+        "initCommand", {"initCommand",
+        "1.1.7",
+        "SQL statement to execute when connecting to the MySQL server. Automatically re-executed if reconnection occurs. ",
+        false,
+        ""}
+      },
     };
 
 //---------------------------------------- Aliases ------------------------------------------------------------------------------------

--- a/src/options/Options.cpp
+++ b/src/options/Options.cpp
@@ -139,7 +139,8 @@ namespace mariadb
     OPTIONS_FIELD(useResetConnection),
     OPTIONS_FIELD(useReadAheadInput),
     OPTIONS_FIELD(serverRsaPublicKeyFile),
-    OPTIONS_FIELD(tlsPeerFP)
+    OPTIONS_FIELD(tlsPeerFP),
+    OPTIONS_FIELD(initCommand)
   };
 
 
@@ -519,6 +520,9 @@ namespace mariadb
     if (!(tlsPeerFPList.compare(opt->tlsPeerFPList) == 0)) {
       return false;
     }
+    if (!(initCommand.compare(opt->initCommand) == 0)) {
+        return false;
+    }
     return minPoolSize == opt->minPoolSize;
   }
 
@@ -615,6 +619,7 @@ namespace mariadb
     result= 31 *result + (!nonMappedOptions.empty() ? hashProps(nonMappedOptions) : 0);
 
     result= 31 *result + (!tlsPeerFPList.empty() ? tlsPeerFPList.hashCode() : 0);
+    result= 31 *result + (!initCommand.empty() ? initCommand.hashCode() : 0);
     return result;
   }
 

--- a/src/options/Options.h
+++ b/src/options/Options.h
@@ -137,6 +137,7 @@ struct Options
   bool      useReadAheadInput= true;
   SQLString serverRsaPublicKeyFile;
   SQLString tlsPeerFP;
+  SQLString initCommand;
 
   SQLString toString() const;
   bool      equals(Options* obj);

--- a/src/protocol/capi/ConnectProtocol.cpp
+++ b/src/protocol/capi/ConnectProtocol.cpp
@@ -428,6 +428,7 @@ namespace capi
 
       compressionHandler(options);
       setConnectionAttributes(options->connectionAttributes);
+      mysql_optionsv(connection.get(), MYSQL_INIT_COMMAND, (void*)options->initCommand.c_str());
     }
     catch (SQLException& sqlException) {
       destroySocket();


### PR DESCRIPTION
This adds support for the MYSQL_INIT_COMMAND option in the connection properties.

Example:
```c++
        sql::Properties properties({
              {"user", "user"},
              {"password", "123"},
              {"autoReconnect", "true"},
              {"initCommand","SET @userid = 5;" }
            });

        conn = std::unique_ptr<sql::Connection>(driver->connect(url, properties));
```
